### PR TITLE
Using gevent version that doesn't break with urllib3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['docopt>=0.6.1', 'gevent>=1.0.1', 'stormpath==1.3.6'],
+    install_requires = ['docopt>=0.6.1', 'gevent>=1.0.2', 'stormpath==1.3.6'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',


### PR DESCRIPTION
I managed to reproduce error reported in issue stormpath/stormpath-sdk-python#164 with gevent version 1.0.1, but didn't with 1.0.2. Seems like they've fixed this in the meantime.